### PR TITLE
CP-2184 add bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,6 @@
+[bumpversion]
+current_version = 1.0.0
+commit = False
+tag = False
+
+[bumpversion:glob:*/src/thousandeyes_sdk/client/version.py]

--- a/thousandeyes-sdk-client/pyproject.toml
+++ b/thousandeyes-sdk-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "thousandeyes-sdk-client"
-version = "1.0.0"
+dynamic = ["version"]
 authors = [
     { name = "ThousandEyes API Team", email = "api-team@thousandeyes.com" }
 ]
@@ -12,6 +12,9 @@ dependencies = [
     "pydantic >=2",
     "typing-extensions >=4.7.1",
 ]
+
+[tool.setuptools.dynamic]
+version = {attr = "thousandeyes_sdk.client.__version__"}
 
 [project.optional-dependencies]
 test = [

--- a/thousandeyes-sdk-client/src/thousandeyes_sdk/client/__init__.py
+++ b/thousandeyes-sdk-client/src/thousandeyes_sdk/client/__init__.py
@@ -2,3 +2,8 @@ from . import exceptions
 from .api_client import ApiClient
 from .api_response import ApiResponse
 from .configuration import Configuration
+from .version import Version
+
+import os.path
+
+__version__ = Version.get()

--- a/thousandeyes-sdk-client/src/thousandeyes_sdk/client/api_client.py
+++ b/thousandeyes-sdk-client/src/thousandeyes_sdk/client/api_client.py
@@ -67,8 +67,6 @@ class ApiClient:
         if header_name is not None:
             self.default_headers[header_name] = header_value
         self.cookie = cookie
-        # Set default User-Agent.
-        self.user_agent = 'ThousandEyesSDK-Python/1.0.0'
         self.client_side_validation = configuration.client_side_validation
 
     def __enter__(self):

--- a/thousandeyes-sdk-client/src/thousandeyes_sdk/client/version.py
+++ b/thousandeyes-sdk-client/src/thousandeyes_sdk/client/version.py
@@ -1,0 +1,6 @@
+import os.path
+
+class Version:
+    @staticmethod
+    def get() -> str:
+        return "1.0.0"


### PR DESCRIPTION
- This PR adds the version to the `client` sdk. All the other sdk's will get the version from this one because they already depend on it. I'll open a follow up PR to rename the `client` to `core` if u agree, didn't want to pollute this PR to much.

- This also adds `bump2version` to manage versioning with a simple command. The following example will bump the major version from the current `1.0.0` to `2.0.0` and replace it in the `version.py` file. It can also generate tags and commit's but rn it's disabled:
```
bump2version major --allow-dirty --verbose
```

- Regarding `user-agent` each api will set it. Example:
```
    def __init__(self, api_client=None) -> None:
        if api_client is None:
            api_client = ApiClient.get_default()
        api_client.user_agent = "ThousandEyesSDK-Python/{0}".format(Version.get())
        self.api_client = api_client
```
It could also be set directly from the `api_client` but then we would lose this if some customer use's it's own implementation of the `api_client`

Related PR:
- [ ] https://github.com/thousandeyes/thousandeyes-sdk-generator/pull/23