### PR TITLE
CP-1897 Release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Build
         run: |
           echo $GITHUB_REF_NAME >> ${{ matrix.package-name }}/.version
-          cp .version LICENSE NOTICE ${{ matrix.package-name }}/  
+          cp LICENSE NOTICE ${{ matrix.package-name }}/  
           python -m build ${{ matrix.package-name }} --outdir dist/
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Tested in https://test.pypi.org with 3 of the projects:
<img width="886" alt="image" src="https://github.com/thousandeyes/thousandeyes-sdk-python/assets/85952626/4e3aae11-098a-475b-978f-d44d6442f2b8">

This is how the client will be able to see the packages: https://test.pypi.org/user/joaomper/ - the Cisco user will be https://pypi.org/user/cisco-open/ as mentioned by Natali.

At the end of the publishing step, we bump the minor versions (can be discussed, as we may want to upgrade the major at times) and commit back to the main repo - we need a PAT, yet again, for this. An example run in my fork: https://github.com/joaomper-TE/thousandeyes-sdk-python/actions/runs/9796829156

![image](https://github.com/thousandeyes/thousandeyes-sdk-python/assets/85952626/c9ffd381-3a7a-47be-8c6b-78376e8ad65b)


