### PR TITLE
doc: Add Support-related documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# code owners
+
+* @brumarqu-te @jabrowne-te @mpragosa-te @phpinhei-te @sfreitas-te @stulowes-te @kevihan-te @goncarva-te @rodrirod-te

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ For more info regarding the API, please check the [Developer support](https://de
 
 ## Support
 
+Join the discussion in the [ThousandEyes Community](https://community.cisco.com/t5/thousandeyes/bd-p/disc-thousandeyes).
 For bug reports, feature requests, or questions about this SDK, please contact [ThousandEyes Support](https://docs.thousandeyes.com/product-documentation/getting-started/getting-support-from-thousandeyes#contacting-support).
 
 ## Roadmap and maintenance


### PR DESCRIPTION
### What changed and why
Updated the README Support section to point users to the ThousandEyes Community and the official ThousandEyes Support page.

### Architecture Diagram
Documentation-only change.

# Checklist:

- [x] Self-review of my own code
- [x] Documentation (SwaggerHub, README, Confluence)
- [ ] Test
- [x] Observability: not applicable for this documentation-only change
- [x] Code style
- [x] Clean code